### PR TITLE
Fix a couple of typos

### DIFF
--- a/BerkeleyDB.pm
+++ b/BerkeleyDB.pm
@@ -2,7 +2,7 @@
 package BerkeleyDB;
 
 
-#     Copyright (c) 1997-9 Paul Marquess. All rights reserved.
+#     Copyright (c) 1997-2019 Paul Marquess. All rights reserved.
 #     This program is free software; you can redistribute it and/or
 #     modify it under the same terms as Perl itself.
 #

--- a/BerkeleyDB.xs
+++ b/BerkeleyDB.xs
@@ -173,7 +173,7 @@ extern "C" {
 #  define AT_LEAST_DB_6_0
 #endif
 
-#if DB_VERSION_MAJOR > 6 || (DB_VERSION_MAJOR == 5 && DB_VERSION_MINOR >= 2)
+#if DB_VERSION_MAJOR > 6 || (DB_VERSION_MAJOR == 6 && DB_VERSION_MINOR >= 2)
 #  define AT_LEAST_DB_6_2
 #endif
 


### PR DESCRIPTION
One's a copyright date out by 20 years.

The other one breaks builds with 5.2 ≤ BDB < 6.2.