### PR TITLE
my_db_strerror: Add missing dTHX declaration

### DIFF
--- a/BerkeleyDB.xs
+++ b/BerkeleyDB.xs
@@ -838,6 +838,9 @@ db_strerror(int err)
 static char *
 my_db_strerror(int err)
 {
+#ifdef dTHX
+    dTHX;
+#endif
     static char buffer[1000] ;
     SV * sv = perl_get_sv(ERR_BUFF, FALSE) ;
     sprintf(buffer, "%d: %s", err, db_strerror(err)) ;


### PR DESCRIPTION
* This function was missing a dTHX check (which is required with
  PERL_NO_GET_CONTEXT), but it wasn't visible unless TRACE was defined.

This fixes the following error:
```
BerkeleyDB.xs: In function ‘my_db_strerror’:
/usr/lib/perl5/5.26/x86_64-cygwin-threads/CORE/perl.h:176:16: error: ‘my_perl’ undeclared (first use in this function); did you mean ‘my_for’?
 #  define aTHX my_perl
                ^
/usr/lib/perl5/5.26/x86_64-cygwin-threads/CORE/perl.h:189:18: note: in expansion of macro ‘aTHX’
 #  define aTHX_  aTHX,
                  ^~~~
/usr/lib/perl5/5.26/x86_64-cygwin-threads/CORE/embed.h:178:34: note: in expansion of macro ‘aTHX_’
 #define get_sv(a,b)  Perl_get_sv(aTHX_ a,b)
                                  ^~~~~
/usr/lib/perl5/5.26/x86_64-cygwin-threads/CORE/embed.h:1932:29: note: in expansion of macro ‘get_sv’
 #  define perl_get_sv(a,b)  get_sv(a,b)
                             ^~~~~~
BerkeleyDB.xs:842:15: note: in expansion of macro ‘perl_get_sv’
     SV * sv = perl_get_sv(ERR_BUFF, FALSE) ;
               ^~~~~~~~~~~
```